### PR TITLE
Add pseries support

### DIFF
--- a/include/pnv.h
+++ b/include/pnv.h
@@ -7,4 +7,15 @@
 
 #define UART_BASE       (LPC_BASE_ADDR + LPC_IO_SPACE + 0x3f8);
 
+#define MSR_HV (1ULL << (63 - 3))
+
+static bool inline is_pnv()
+{
+	unsigned long msr;
+
+	__asm__ volatile ("mfmsr %0"
+			  : "=r" (msr)
+			  : : "memory");
+	return !!(msr & MSR_HV);
+}
 #endif


### PR DESCRIPTION
Leaving this here just in case. I think it is useful because we can run the tests with KVM and compare with real hardware.

Some points:
- I think it would be best if we added the endian fixup back to the tests instead of using a modified QEMU. The entry point switch is more palatable for upstream I think, so that would be fine.
- We might want to come up with a replacement for `attn` for pseries. It **does** work with TCG, but with KVM the facility is not enabled by the kernel.