### PR TITLE
Fix clean target by specifying needed shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # XICS not supported
 
+SHELL := bash
+
 SUBDIRS := decrementer spr_read  modes sc reservation trace fpu privileged mmu misc illegal alignment
 TARGETS := all check
 


### PR DESCRIPTION
The clean target uses some shell extensions that doesn't work with Ubuntu's default dash shell.
Request bash to be used to fix this.