### PR TITLE
Allow MMU test to start in BE

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -38,6 +38,7 @@ clean:
 	@rm -f *.o $(TEST).elf $(TEST).bin $(TEST).hex
 
 QEMU ?= qemu-system-ppc64
+ENDIANNESS ?= ,endianness=little
 
 check:
-	$(QEMU) -M powernv9,endianness=little -bios $(TEST).bin	-serial mon:stdio -nographic
+	$(QEMU) -M powernv9$(ENDIANNESS) -bios $(TEST).bin -serial mon:stdio -nographic

--- a/mmu/Makefile
+++ b/mmu/Makefile
@@ -1,3 +1,4 @@
 TEST=mmu
+ENDIANNESS=
 
 include ../Makefile.test

--- a/mmu/head.S
+++ b/mmu/head.S
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
+#define SPR_HID0		0x3f0
+#define SPR_HID0_POWER9_HILE	0x0800000000000000
+
+#define FIXUP_ENDIAN \
+	tdi   0,0,0x48;   /* Reverse endian of b . + 8 */           \
+	b     $+44;       /* Skip trampoline if endian is good */   \
+	.long 0xa600607d; /* mfmsr r11 */                           \
+	.long 0x01006b69; /* xori r11,r11,1 */                      \
+	.long 0x00004039; /* li r10,0 */                            \
+	.long 0x6401417d; /* mtmsrd r10,1 */                        \
+	.long 0x05009f42; /* bcl 20,31,$+4 */                       \
+	.long 0xa602487d; /* mflr r10 */                            \
+	.long 0x14004a39; /* addi r10,r10,20 */                     \
+	.long 0xa6035a7d; /* mtsrr0 r10 */                          \
+	.long 0xa6037b7d; /* mtsrr1 r11 */                          \
+	.long 0x2400004c  /* rfid */
+
 /* Load an immediate 64-bit value into a register */
 #define LOAD_IMM64(r, e)			\
 	lis     r,(e)@highest;			\
@@ -35,6 +52,12 @@ _start:
 	. = 0x10
 .global start
 start:
+	FIXUP_ENDIAN
+	mfspr	%r10, SPR_HID0
+	LOAD_IMM64(%r11, SPR_HID0_POWER9_HILE)
+	or	%r10, %r10, %r11
+	mtspr	SPR_HID0, %r10
+
 	LOAD_IMM64(%r10,__bss_start)
 	LOAD_IMM64(%r11,__bss_end)
 	subf	%r11,%r10,%r11


### PR DESCRIPTION
Make it possible to use QEMU versions that don't support the
machine endianness property, that allows the CPU to start in LE,
to run the MMU tests.