### PR TITLE
mmu: Add support for pseries/kvm

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -45,3 +45,7 @@ ENDIANNESS ?= ,endianness=little
 
 check:
 	$(QEMU) -M powernv9$(ENDIANNESS) -bios $(TEST).bin -serial mon:stdio -nographic
+check-pseries:
+	$(QEMU) -M pseries$(ENDIANNESS) -bios $(TEST).bin -serial mon:stdio -nographic
+check-kvm:
+	$(QEMU) -accel kvm -M pseries$(ENDIANNESS) -bios $(TEST).bin -serial mon:stdio -nographic

--- a/Makefile.test
+++ b/Makefile.test
@@ -15,13 +15,16 @@ LD = $(CROSS_COMPILE)ld
 OBJCOPY = $(CROSS_COMPILE)objcopy
 
 CFLAGS = -Os -g -Wall -std=c99 -nostdinc -msoft-float -mno-string -mno-multiple -mno-vsx -mno-altivec -fno-stack-protector -mstrict-align -ffreestanding -fdata-sections -ffunction-sections -I $(TOP_DIR)/include -isystem $(shell $(CC) -print-file-name=include)
+LDFLAGS = -T powerpc.lds
+
 ifeq ($(BIG),1)
 CFLAGS += -mcpu=power8 -mbig-endian -mabi=elfv2
+LDFLAGS += -EB
 else
 CFLAGS += -mlittle-endian
+LDFLAGS += -EL
 endif
 ASFLAGS = $(CFLAGS)
-LDFLAGS = -T powerpc.lds
 
 all: $(TEST).bin
 

--- a/mmu/head.S
+++ b/mmu/head.S
@@ -17,6 +17,15 @@
 #define SPR_HID0		0x3f0
 #define SPR_HID0_POWER9_HILE	0x0800000000000000
 
+#define H_REGISTER_PROC_TBL	0x37c
+#define PROCTAB_NEW		0x18
+#define PROCTAB_RADIX		0x04
+#define PROCTAB_GTSE		0x01
+
+#define H_SET_MODE		0x31c
+#define RESOURCE_LPCR_ILE	4
+#define MFLAGS_SET		1
+
 #define FIXUP_ENDIAN \
 	tdi   0,0,0x48;   /* Reverse endian of b . + 8 */           \
 	b     $+44;       /* Skip trampoline if endian is good */   \
@@ -50,14 +59,34 @@ _start:
 	b start
 
 	. = 0x10
+	FIXUP_ENDIAN
+	b start
+
+	. = 0x100
+	FIXUP_ENDIAN
 .global start
 start:
-	FIXUP_ENDIAN
 #ifdef __LITTLE_ENDIAN__
+	/* Set ILE */
+
+	/* Check if HV is set */
+	mfmsr	%r9
+	rldicl.	%r9,%r9,4,63
+	beq	1f
+	/* True: set POWER9_HILE in HID0 SPR */
 	mfspr	%r10, SPR_HID0
 	LOAD_IMM64(%r11, SPR_HID0_POWER9_HILE)
 	or	%r10, %r10, %r11
 	mtspr	SPR_HID0, %r10
+	b 2f
+	/* False: Set LPCR[ILE] with an hcall */
+1:	li	%r3,H_SET_MODE
+	li	%r4,MFLAGS_SET
+	li	%r5,RESOURCE_LPCR_ILE
+	li	%r6,0		/* value1 */
+	li	%r7,0		/* value2 */
+	sc	1
+2:
 #endif
 
 	LOAD_IMM64(%r10,__bss_start)
@@ -207,3 +236,13 @@ test_1:	b	test_return
 	/* test flowing from one page to the next */
 test_2:	nop
 	b	test_return
+
+	.globl	register_process_table
+register_process_table:
+	mr	%r5,%r3		/* proctab PA */
+	mr	%r7,%r4		/* proctab size shift */
+	li	%r3,H_REGISTER_PROC_TBL
+	li	%r4,PROCTAB_NEW | PROCTAB_RADIX | PROCTAB_GTSE
+	li	%r6,0
+	sc	1
+	blr

--- a/mmu/mmu.c
+++ b/mmu/mmu.c
@@ -75,6 +75,15 @@ static uint64_t msr_dflt;
 #define DFLT_PERM	(PERM_WR | PERM_RD | REF | CHG)
 
 /*
+ * Minimum VA/PA addresses to use in tests, to avoid overwriting code
+ * or data areas.
+ */
+#define MIN_VA		0x4000000
+#define MIN_PA		0x4000000
+#define VA(v)		(MIN_VA + (v))
+#define PA(p)		(MIN_PA + (p))
+
+/*
  * MicroWatt MMU config
  *
  * Use a Radix Tree with 2 levels, mapping 2GB (the minimum size possible),
@@ -429,7 +438,7 @@ void unmap_all(void)
 
 int mmu_test_1(void)
 {
-	long *ptr = (long *) 0x123000;
+	long *ptr = (long *) VA(0x123000);
 	long val;
 
 	/* this should fail */
@@ -446,9 +455,9 @@ int mmu_test_1(void)
 
 int mmu_test_2(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
-	long *ptr2 = (long *) 0x1124000;
+	long *mem = (long *)  PA(0x010000);
+	long *ptr = (long *)  VA(0x810000);
+	long *ptr2 = (long *) VA(0x820000);
 	long val;
 
 	/* create PTE */
@@ -479,8 +488,8 @@ int mmu_test_2(void)
 
 int mmu_test_3(void)
 {
-	long *mem = (long *) 0x9000;
-	long *ptr = (long *) 0x14a000;
+	long *mem = (long *) PA(0x020000);
+	long *ptr = (long *) VA(0x800000);
 	long val;
 
 	/* create PTE */
@@ -509,9 +518,9 @@ int mmu_test_3(void)
 
 int mmu_test_4(void)
 {
-	long *mem = (long *) 0xa000;
-	long *ptr = (long *) 0x10b000;
-	long *ptr2 = (long *) 0x110b000;
+	long *mem = (long *)  PA(0x020000);
+	long *ptr = (long *)  VA(0x820000);
+	long *ptr2 = (long *) VA(0x8b0000);
 	long val;
 
 	/* create PTE */
@@ -543,8 +552,8 @@ int mmu_test_4(void)
 
 int mmu_test_5(void)
 {
-	long *mem = (long *) 0xbffd;
-	long *ptr = (long *) 0x39fffd;
+	long *mem = (long *) PA(0x08bffd);
+	long *ptr = (long *) VA(0x89fffd);
 	long val;
 
 	/* create PTE */
@@ -563,8 +572,8 @@ int mmu_test_5(void)
 
 int mmu_test_6(void)
 {
-	long *mem = (long *) 0xbffd;
-	long *ptr = (long *) 0x39fffd;
+	long *mem = (long *) PA(0x08bffd);
+	long *ptr = (long *) VA(0x89fffd);
 
 	/* create PTE */
 	map(ptr, mem, DFLT_PERM);
@@ -581,8 +590,8 @@ int mmu_test_6(void)
 
 int mmu_test_7(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
+	long *mem = (long *) PA(0x080000);
+	long *ptr = (long *) VA(0x280000);
 	long val;
 
 	*mem = 0x123456789abcdef0;
@@ -611,8 +620,8 @@ int mmu_test_7(void)
 
 int mmu_test_8(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
+	long *mem = (long *) PA(0x080000);
+	long *ptr = (long *) VA(0x220000);
 	long val;
 
 	*mem = 0x123456789abcdef0;
@@ -635,8 +644,8 @@ int mmu_test_8(void)
 
 int mmu_test_9(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
+	long *mem = (long *) PA(0x080000);
+	long *ptr = (long *) VA(0x220000);
 	long val;
 
 	*mem = 0x123456789abcdef0;
@@ -665,8 +674,8 @@ int mmu_test_9(void)
 
 int mmu_test_10(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
+	long *mem = (long *) PA(0x080000);
+	long *ptr = (long *) VA(0x220000);
 	long val;
 
 	*mem = 0x123456789abcdef0;
@@ -689,7 +698,7 @@ int mmu_test_10(void)
 
 int mmu_test_11(void)
 {
-	unsigned long ptr = 0x523000;
+	unsigned long ptr = VA(0x080000);
 
 	/* this should fail */
 	if (test_exec(0, ptr, MSR_DFLT | MSR_IR))
@@ -703,9 +712,9 @@ int mmu_test_11(void)
 
 int mmu_test_12(void)
 {
-	unsigned long mem = 0x1000;
-	unsigned long ptr = 0x324000;
-	unsigned long ptr2 = 0x1324000;
+	unsigned long mem =  0x1000;
+	unsigned long ptr =  VA(0x201000);
+	unsigned long ptr2 = VA(0x231000);
 
 	/* create PTE */
 	map((void *)ptr, (void *)mem, PERM_EX | REF);
@@ -722,9 +731,9 @@ int mmu_test_12(void)
 
 int mmu_test_13(void)
 {
-	unsigned long mem = 0x1000;
-	unsigned long ptr = 0x349000;
-	unsigned long ptr2 = 0x34a000;
+	unsigned long mem =  0x1000;
+	unsigned long ptr =  VA(0x201000);
+	unsigned long ptr2 = VA(0x221000);
 
 	/* create a PTE */
 	map((void *)ptr, (void *)mem, PERM_EX | REF);
@@ -747,20 +756,24 @@ int mmu_test_13(void)
 
 int mmu_test_14(void)
 {
-	unsigned long mem = 0x1000;
+	unsigned long mem =  0x1000;
 	unsigned long mem2 = 0x2000;
-	unsigned long ptr = 0x30a000;
-	unsigned long ptr2 = 0x30b000;
+	unsigned long ptr =  VA(0x211000);
+	unsigned long ptr2 = VA(0x212000);
 
 	/* create a PTE */
 	map((void *)ptr, (void *)mem, PERM_EX | REF);
-	/* this should fail due to second page not being mapped */
-	if (test_exec(2, ptr, MSR_DFLT | MSR_IR))
-		return 1;
-	/* SRR0 and SRR1 should be set correctly */
-	if (mfspr(SRR0) != ptr2 ||
-	    mfspr(SRR1) != (MSR_DFLT | 0x40000000 | MSR_IR))
-		return 2;
+
+	if (PAGE_SHIFT == 12) {
+		/* this should fail due to second page not being mapped */
+		if (test_exec(2, ptr, MSR_DFLT | MSR_IR))
+			return 1;
+		/* SRR0 and SRR1 should be set correctly */
+		if (mfspr(SRR0) != ptr2 ||
+		    mfspr(SRR1) != (MSR_DFLT | 0x40000000 | MSR_IR))
+			return 2;
+	}
+
 	/* create a PTE for the second page */
 	map((void *)ptr2, (void *)mem2, PERM_EX | REF);
 	/* this should succeed */
@@ -772,7 +785,7 @@ int mmu_test_14(void)
 int mmu_test_15(void)
 {
 	unsigned long mem = 0x1000;
-	unsigned long ptr = 0x324000;
+	unsigned long ptr = VA(0x201000);
 
 	/* create a PTE without execute permission */
 	map((void *)ptr, (void *)mem, DFLT_PERM);
@@ -788,22 +801,26 @@ int mmu_test_15(void)
 
 int mmu_test_16(void)
 {
-	unsigned long mem = 0x1000;
+	unsigned long mem =  0x1000;
 	unsigned long mem2 = 0x2000;
-	unsigned long ptr = 0x30a000;
-	unsigned long ptr2 = 0x30b000;
+	unsigned long ptr =  VA(0x211000);
+	unsigned long ptr2 = VA(0x212000);
 
 	/* create a PTE */
 	map((void *)ptr, (void *)mem, PERM_EX | REF);
 	/* create a PTE for the second page without execute permission */
 	map((void *)ptr2, (void *)mem2, PERM_RD | REF);
-	/* this should fail due to second page being no-execute */
-	if (test_exec(2, ptr, MSR_DFLT | MSR_IR))
-		return 1;
-	/* SRR0 and SRR1 should be set correctly */
-	if (mfspr(SRR0) != ptr2 ||
-	    mfspr(SRR1) != (MSR_DFLT | 0x10000000 | MSR_IR))
-		return 2;
+
+	if (PAGE_SHIFT == 12) {
+		/* this should fail due to second page being no-execute */
+		if (test_exec(2, ptr, MSR_DFLT | MSR_IR))
+			return 1;
+		/* SRR0 and SRR1 should be set correctly */
+		if (mfspr(SRR0) != ptr2 ||
+		    mfspr(SRR1) != (MSR_DFLT | 0x10000000 | MSR_IR))
+			return 2;
+	}
+
 	/* create a PTE for the second page with execute permission */
 	map((void *)ptr2, (void *)mem2, PERM_RD | PERM_EX | REF);
 	/* this should succeed */
@@ -815,7 +832,7 @@ int mmu_test_16(void)
 int mmu_test_17(void)
 {
 	unsigned long mem = 0x1000;
-	unsigned long ptr = 0x349000;
+	unsigned long ptr = VA(0x201000);
 
 #ifndef SKIP_RC_TESTS
 	/* create a PTE without the ref bit set */
@@ -845,9 +862,9 @@ int mmu_test_17(void)
 
 int mmu_test_18(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
-	long *ptr2 = (long *) 0x1124000;
+	long *mem = (long *)  PA(0x080000);
+	long *ptr = (long *)  VA(0x220000);
+	long *ptr2 = (long *) VA(0x260000);
 
 	/* create PTE */
 	map(ptr, mem, DFLT_PERM);
@@ -864,8 +881,8 @@ int mmu_test_18(void)
 
 int mmu_test_19(void)
 {
-	long *mem = (long *) 0x8000;
-	long *ptr = (long *) 0x124000;
+	long *mem = (long *) PA(0x080000);
+	long *ptr = (long *) VA(0x280000);
 
 	*mem = 0x123456789abcdef0;
 	/* create PTE with read but not write permission */
@@ -890,8 +907,8 @@ int mmu_test_20(void)
 	 * NOTE: keep everything that will be used with DR=1 on registers,
 	 *       to avoid DSIs caused by unmaped memory.
 	 */
-	long *mem = (long *) 0xa00000;
-	register long *ptr = (long *) 0x1230000;
+	long *mem = (long *)          PA(0x080000);
+	register long *ptr = (long *) VA(0x280000);
 	long val = 0x0123456789ABCDEF;
 	long ret;
 	register unsigned long msr, ret2;

--- a/mmu/mmu.c
+++ b/mmu/mmu.c
@@ -98,6 +98,16 @@ static uint64_t msr_dflt;
 #define PATS		0	/* 2^(12+0) = 4K */
 #define PARTTAB_SIZE	0x1000
 
+/*
+ * Partition Page Dir (PPD)
+ *
+ * Use 2M large pages in the PPD.
+ */
+#define PPD_ADDR_BITS	31
+#define PPD_L1_BITS	10
+#define PPD_L2_BITS	9
+#define PPD_PA_INC	(1ul << (PPD_ADDR_BITS - PPD_L1_BITS))
+
 /* Process Table size */
 #define PROCTAB_SIZE_SHIFT 0	/* 2^(0 + 12) = 4K */
 
@@ -117,11 +127,6 @@ static uint64_t msr_dflt;
 
 #define PAGE_SIZE	(1ul << PAGE_SHIFT)
 #define PAGE_MASK	(PAGE_SIZE - 1)
-
-/* Partition Page Dir params */
-#define PPD_L1_BITS	5
-#define PPD_L2_BITS	14	/* virtual level 2 PGD address bits */
-#define PPD_PA_INC	(1ul << (PAGE_SHIFT + PPD_L2_BITS))
 
 /* TLB definitions */
 

--- a/mmu/mmu.c
+++ b/mmu/mmu.c
@@ -26,11 +26,8 @@
 #define MSR_HV	0x1000000000000000ul
 #define MSR_SF	0x8000000000000000ul
 
-#ifdef __LITTLE_ENDIAN__
-#define MSR_DFLT	(MSR_SF | MSR_HV | MSR_LE)
-#else
-#define MSR_DFLT	(MSR_SF | MSR_HV)
-#endif
+static uint64_t msr_dflt;
+#define MSR_DFLT	msr_dflt
 
 extern int test_read(long *addr, long *ret, long init);
 extern int test_write(long *addr, long val);
@@ -279,8 +276,10 @@ void init_partition_table(void)
 
 void init_mmu(void)
 {
-	init_partition_table();
+	msr_dflt = mfmsr() | MSR_SF;
+	mtmsrd(msr_dflt);
 	init_process_table();
+	init_partition_table();
 }
 
 static unsigned long *read_pgd(unsigned long i)


### PR DESCRIPTION
This patch series add support for running the MMU tests on pseries machines, optionally with kvm acceleration.

The main changes were:
- Splitting partition and process table setup
- When on pseries, use hypercalls instead of configuring the hardware directly
- Use 4-level Radix Trees, instead of the simpler 2-level ones used by Microwatt. POWER9 (and kvm) doesn't support the Microwatt config.
- Adapt the tests to make them work with 64K pages too

Microwatt config may be selected by setting POWER9_MMU to 0, but it may be removed later, if we think that it's not necessary to keep the original Microwatt MMU setup.

NOTE: Since the `attn` instruction doesn't work on pseries, QEMU hangs after running all tests. We still need to figure out how to exit returning an status code on pseries.